### PR TITLE
fix:allow supportPhoneNumber not to be provided

### DIFF
--- a/shellrecharge/models.py
+++ b/shellrecharge/models.py
@@ -139,7 +139,7 @@ class Location(BaseModel):
     openingHours: Optional[list[OpeningHours]] = []
     updated: DateTimeISO8601
     locationType: str
-    supportPhoneNumber: str
+    supportPhoneNumber: Optional[str] = ""
     facilities: Optional[list[str]] = []
     predictedOccupancies: Optional[list[PredictedOccupancies]] = []
     suboperatorName: Optional[str] = ""


### PR DESCRIPTION
Hello,

I came across an EV charging point (`BE-TCB-P120829`) which did not have the `supportPhoneNumber` attribute.

This PR should fix that issue.

Would it also be possible to update your Home Assistant integration afterwards?