### PR TITLE
feat: throw exception when rate limit has been hit

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ import aiohttp
 from aiohttp.client_exceptions import ClientError
 
 import shellrecharge
-from shellrecharge import LocationEmptyError, LocationValidationError
+from shellrecharge import LocationEmptyError, LocationValidationError, RateLimitHitError
 
 
 async def main():
@@ -86,6 +86,8 @@ async def main():
         except LocationValidationError as err:
             logging.error("Location validation error {}, report locaton id" % err)
         except (ClientError, TimeoutError, CancelledError) as err:
+            logging.error(err)
+        except RateLimitHitError as err:
             logging.error(err)
 
 

--- a/shellrecharge/__init__.py
+++ b/shellrecharge/__init__.py
@@ -50,6 +50,8 @@ class Api:
                             location = Location.model_validate(result[0])
                     else:
                         raise LocationEmptyError()
+                elif response.status == 429:
+                    raise RateLimitHitError("Rate limit of API has been hit")
                 else:
                     self.logger.exception(
                         "HTTPError %s occurred while requesting %s",
@@ -83,5 +85,11 @@ class LocationEmptyError(Exception):
 
 class LocationValidationError(Exception):
     """Raised when returned Location API data is in the wrong format."""
+
+    pass
+
+
+class RateLimitHitError(Exception):
+    """Raised when the rate limit of the API has been hit."""
 
     pass


### PR DESCRIPTION
When querying the API a lot, a 429 is returned for a while. I though it would be a nice addition to throw an exception for this. This way applications using this library now when to cool down for a while.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added explicit handling for API rate limiting: a dedicated RateLimitHitError is raised when limits are exceeded, enabling apps to catch and respond gracefully.
  * Provides a clearer, user-friendly error message when rate limits are hit.
  * Exposes the new RateLimitHitError for consumer use.

* Documentation
  * Updated README example to demonstrate importing and catching RateLimitHitError, including logging guidance for rate-limit scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->